### PR TITLE
Support 5.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Authentication module for Kibana 5
 ==================================
-Authentication module for Kibana 5.1.2 (should work with kibana 5.x as long as the version number in the package.json matches) and Elasticfence HTTP Authentication plugin
+Authentication module for Kibana 5.4.1 (should work with kibana 5.x as long as the version number in the package.json matches) and Elasticfence HTTP Authentication plugin
 
 **Login**
 

--- a/__gulpfile.js
+++ b/__gulpfile.js
@@ -19,7 +19,7 @@ var packageName = pkg.name  + '-' + pkg.version;
 // relative location of Kibana install
 var pathToKibana = config.relativePathToKibana;
 
-var buildDir = path.resolve(__dirname, 'build');
+var buildDir = path.resolve(__dirname, 'build', 'kibana');
 var targetDir = path.resolve(__dirname, 'target');
 var buildTarget = path.resolve(buildDir, pkg.name);
 var kibanaPluginDir = path.resolve(__dirname, pathToKibana, 'plugins');

--- a/__gulpfile.js
+++ b/__gulpfile.js
@@ -19,9 +19,10 @@ var packageName = pkg.name  + '-' + pkg.version;
 // relative location of Kibana install
 var pathToKibana = config.relativePathToKibana;
 
-var buildDir = path.resolve(__dirname, 'build', 'kibana');
+var buildDir = path.resolve(__dirname, 'build')
+var pkgDir = path.resolve(buildDir, 'kibana');
 var targetDir = path.resolve(__dirname, 'target');
-var buildTarget = path.resolve(buildDir, pkg.name);
+var buildTarget = path.resolve(pkgDir, pkg.name);
 var kibanaPluginDir = path.resolve(__dirname, pathToKibana, 'plugins');
 
 var include = [
@@ -96,7 +97,7 @@ gulp.task('build', ['clean'], function (done) {
 });
 
 gulp.task('package', ['build'], function (done) {
-  return gulp.src(path.join(buildDir, '**', '*'))
+  return gulp.src(path.join(buildDir, '**'))
     .pipe(tar(packageName + '.tar'))
     .pipe(gzip())
     .pipe(gulp.dest(targetDir));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kibana-auth-plugin",
-  "version": "5.1.2",
+  "version": "5.4.1",
   "description": "Elasticfence authentication for kibana",
   "main": "gulpfile.js",
   "homepage": "https://github.com/elasticfence/kibana-auth-elasticfence",


### PR DESCRIPTION
When using with Kibana 5.4.x, the package configuration of the plugin has changed, so you can not install this plugin.
I added "kibana" direcroty to the root of build source path that I built.
as follows.
```
build
└── kibana
    └── kibana-auth-plugin
        ├── index.js
        ├── node_modules
        │   ├── crypto
        │   │   ├── History.md
        │   │   ├── Readme.md
        │   │   ├── md5.js
        │   │   ├── package.json
        │   │   ├── sha1.js
        │   │   └── test
        │   │       └── test-crypto.js
        │   ├── hapi-auth-cookie
        │   │   ├── CONTRIBUTING.md
        │   │   ├── LICENSE
        │   │   ├── README.md
        │   │   ├── example
        │   │   │   └── index.js
        │   │   ├── lib
        │   │   │   └── index.js
        │   │   ├── package.json
        │   │   └── test
        │   │       └── index.js
        │   ├── typedarray
        │   │   └── test
        │   │       └── server
        │   │           └── undef_globals.js
        │   └── uuid
        │       ├── AUTHORS
        │       ├── HISTORY.md
        │       ├── LICENSE.md
        │       ├── README.md
        │       ├── bin
        │       │   └── uuid
        │       ├── index.js
        │       ├── lib
        │       │   ├── bytesToUuid.js
        │       │   ├── rng-browser.js
        │       │   ├── rng.js
        │       │   ├── sha1-browser.js
        │       │   └── sha1.js
        │       ├── package.json
        │       ├── v1.js
        │       ├── v4.js
        │       └── v5.js
        ├── package.json
        ├── public
        │   ├── app.js
        │   └── logout
        │       ├── logout.html
        │       └── logout.js
        └── server
            └── auth-local-cookie.js
```

Please check this pull request.