### PR TITLE
Fix plugin install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Requires:
 
 ## Setup
 ```
-bin/kibana plugin --install kibana-auth-plugin -u https://github.com/elasticfence/kibana-auth-elasticfence/releases/download/5.x/kauth-latest.tar.gz
+bin/kibana plugin install https://github.com/elasticfence/kibana-auth-elasticfence/releases/download/5.x/kauth-latest.tar.gz
 ```
 
 ## Usage


### PR DESCRIPTION
The ```--``` next to ```install``` is not recognizable as command.